### PR TITLE
Implemented getIterCount method for GMRES solver in python interface

### DIFF
--- a/src/bpmat/KSM.cpp
+++ b/src/bpmat/KSM.cpp
@@ -779,7 +779,7 @@ void GMRES::solve( TACSVec *b, TACSVec *x, int zero_guess ){
       rhs_norm = res[0]; // The initial residual 
     }  
 
-    int niters = 0; // Keep track of the size of the Hessenberg matrix  
+    niters = 0; // Keep track of the size of the Hessenberg matrix  
 
     if (TacsRealPart(res[0]) < atol){
       break;

--- a/src/bpmat/KSM.h
+++ b/src/bpmat/KSM.h
@@ -390,6 +390,8 @@ class GMRES : public TACSKsm {
   void setMonitor( KSMPrint *_monitor );
   void setOrthoType( enum OrthoType otype );
   void setTimeMonitor();
+  int getIterCount(){return niters;}
+
 
   const char *TACSObjectName();
 
@@ -406,6 +408,7 @@ class GMRES : public TACSKsm {
   int msub;
   int nrestart;
   int isFlexible;
+  int niters;
 
   TACSVec **W;   // The Arnoldi vectors that span the Krylov subspace
   TACSVec **Z;   // An additional flexible subspace of vectors

--- a/tacs/TACS.pxd
+++ b/tacs/TACS.pxd
@@ -128,6 +128,7 @@ cdef extern from "KSM.h":
         GMRES(TACSMat *_mat, TACSPc *_pc, int _m,
               int _nrestart, int _isFlexible )
         void setTimeMonitor()
+        int getIterCount()
 
 cdef extern from "BVec.h":
     cdef cppclass TACSBVec(TACSVec):

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -686,6 +686,14 @@ cdef class KSM:
         if gmres_ptr != NULL:
             gmres_ptr.setTimeMonitor()
 
+    def getIterCount(self):
+        '''
+        Return the number of iterations taken for the linear solve
+        '''
+        cdef GMRES *gmres_ptr = NULL
+        gmres_ptr = _dynamicGMRES(self.ptr)
+        if gmres_ptr != NULL:
+            return gmres_ptr.getIterCount()
 
 cdef class Assembler:
     def __cinit__(self):


### PR DESCRIPTION
getIterCount method allows us to get the number of iteration taken for the last GMRES solve through the python interface which is required by the nonlinear solver.

Tested on the pytacs plate example